### PR TITLE
switch "change wallet" button text to be more clear

### DIFF
--- a/html/sendNas.html
+++ b/html/sendNas.html
@@ -57,7 +57,7 @@
 
     <div class="container change_wallet active1">
         <div>Your wallet file is imported.</div>
-        <button id="change-wallet"  class="btn btn-block">change another wallet</button>
+        <button id="change-wallet"  class="btn btn-block">switch to a different wallet</button>
     </div>
 
     <div id=send class="container send">


### PR DESCRIPTION
The current change wallet button is both broken English and ambiguous as to its function. "another" is replaced with "a different" to emphasize that you are swapping, rather than combining something. "switch" is used rather than "change" because it reads slightly better, and because the word "change" can be confusing in a financial context. The word "to" is used to indicate that you are moving from one state to a different state, rather than just applying an action called "switch" or "change" to a wallet. The lack of the word "to" is also what makes it read most like broken English.